### PR TITLE
Emitting Pathways metrics from PathwaysJob.

### DIFF
--- a/api/v1/pathwaysjob_types.go
+++ b/api/v1/pathwaysjob_types.go
@@ -137,6 +137,10 @@ type ControllerSpec struct {
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="deploymentMode is immutable"
 	DeploymentMode DeploymentMode `json:"deploymentMode,omitempty"`
 
+	// Enables metrics collection for the PathwaysJob
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="enableMetricsCollection is immutable"
+	EnableMetricsCollection bool `json:"enableMetricsCollection,omitempty"`
+
 	// UserPodTemplate accepts a pod composed of user's workload
 	// (and other) containers.
 	// https://pkg.go.dev/k8s.io/api/core/v1#PodTemplateSpec

--- a/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
+++ b/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
@@ -77,6 +77,12 @@ spec:
                     x-kubernetes-validations:
                     - message: deploymentMode is immutable
                       rule: self == oldSelf
+                  enableMetricsCollection:
+                    description: Enables metrics collection for the PathwaysJob
+                    type: boolean
+                    x-kubernetes-validations:
+                    - message: enableMetricsCollection is immutable
+                      rule: self == oldSelf
                   template:
                     description: |-
                       UserPodTemplate accepts a pod composed of user's workload


### PR DESCRIPTION
Adding EnableMetricsCollection to the PathwaysJob API to allow metrics collection. Enabling a flag on the worker, proxy and server if this flag is provided.