### PR TITLE
Rename Remote Python to Colocated Python & Replace Colocate mode with ColocateHeadWithWorkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ PathwaysJob API is an OSS Kubernetes-native API, to deploy ML training and batch
 //ToDo(roshanin) - add intro for Pathways.
 ## Description
 The PathwaysJob is an API that provides an easy way to run JAX workloads using Pathways. It support two modes of deployment. A PathwaysJob instance bundles the Pathways resource manager(RM) AKA Pathways server, the Pathways proxy server and the user workload containers into a single pod called "pathways-head". When the user pod is not provided (headless workloads), the "pathways-head" pod consists of the Pathways RM and the proxy server.
-### Colocate mode
-The 'colocate' mode deploys the "pathways-head" pod besides a "worker" pod on one of the TPU workers. This is preferred for Pathways batch inference workloads, where latency is crucial.
+### ColocateHeadWithWorkers mode
+The 'colocate_head_with_workers' mode deploys the "pathways-head" pod besides a "worker" pod on one of the TPU workers. This is preferred for Pathways batch inference workloads, where latency is crucial.
 ### Default mode
 The "pathways-head" pod is schedule on a CPU nodepool and the "workers" are scheduled on TPUs. The default mode is preferred for Pathways training workloads where the worker utilizes the TPUs completely.
 ### With a dockerized workload

--- a/api/v1/pathwaysjob_types.go
+++ b/api/v1/pathwaysjob_types.go
@@ -94,12 +94,12 @@ type PathwaysJobSpec struct {
 	CustomComponents []CustomComponentsSpec `json:"customComponents,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=colocate;default
+// +kubebuilder:validation:Enum=colocate_head_with_workers;default
 type DeploymentMode string
 
 const (
-	Colocate DeploymentMode = "colocate"
-	Default  DeploymentMode = "default"
+	ColocateHeadWithWorkers DeploymentMode = "colocate_head_with_workers"
+	Default                 DeploymentMode = "default"
 )
 
 // +kubebuilder:validation:Enum=ct6e-standard-4t;ct6e-standard-8t;ct5p-hightpu-4t;ct5lp-hightpu-4t;ct5lp-hightpu-8t;ct4p-hightpu-4t
@@ -139,7 +139,7 @@ type WorkerSpec struct {
 type ControllerSpec struct {
 	// DeploymentMode defines whether the user job and the Pathways
 	// resources (RM, proxy) must be colocated on TPUs, with the Pathways
-	// workers or not. If user chooses to "colocate", then the Pathways RM
+	// workers or not. If user chooses to "colocate_head_with_workers", then the Pathways RM
 	// and proxy run together with the user job as a single pod.
 	// Users may opt for "default" placement where scheduler places the
 	// RM pod and the proxy pod on the CPU nodepools by default. User
@@ -175,7 +175,7 @@ type CustomComponentsSpec struct {
 	CustomFlags []string `json:"customFlags,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=pathways_server;worker;proxy_server;remote_python_sidecar
+// +kubebuilder:validation:Enum=pathways_server;worker;proxy_server;colocated_python_sidecar
 type PathwaysComponentType string
 
 const (
@@ -185,8 +185,8 @@ const (
 	PathwaysProxy PathwaysComponentType = "proxy_server"
 	// Pathways worker component
 	PathwaysWorker PathwaysComponentType = "worker"
-	//Pathways remote python sidecar component, hosted on the workers.
-	PathwaysRemotePythonSidecar PathwaysComponentType = "remote_python_sidecar"
+	//Pathways colocated python sidecar component, hosted on the workers.
+	PathwaysColocatedPythonSidecar PathwaysComponentType = "colocated_python_sidecar"
 )
 
 // PathwaysJobStatus defines the observed state of PathwaysJob

--- a/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
+++ b/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
@@ -65,13 +65,13 @@ spec:
                     description: |-
                       DeploymentMode defines whether the user job and the Pathways
                       resources (RM, proxy) must be colocated on TPUs, with the Pathways
-                      workers or not. If user chooses to "colocate", then the Pathways RM
+                      workers or not. If user chooses to "colocate_head_with_workers", then the Pathways RM
                       and proxy run together with the user job as a single pod.
                       Users may opt for "default" placement where scheduler places the
                       RM pod and the proxy pod on the CPU nodepools by default. User
                       workload will be deployed separately, as a pod.
                     enum:
-                    - colocate
+                    - colocate_head_with_workers
                     - default
                     type: string
                     x-kubernetes-validations:
@@ -8100,7 +8100,7 @@ spec:
                       - pathways_server
                       - worker
                       - proxy_server
-                      - remote_python_sidecar
+                      - colocated_python_sidecar
                       type: string
                     customFlags:
                       description: Custom flags to be provided to this component.

--- a/config/samples/colocated_python_example_pathwaysjob.yaml
+++ b/config/samples/colocated_python_example_pathwaysjob.yaml
@@ -15,12 +15,12 @@
 apiVersion: pathways-job.pathways.domain/v1
 kind: PathwaysJob
 metadata:
-  name: pathways-remotepython-trial
+  name: pathways-colocatedpython-trial
 spec:
   maxRestarts: 0
   customComponents:
-  - componentType: remote_python_sidecar
-    image: <Remote python sidecar image> # Provide remote python sidecar image
+  - componentType: colocated_python_sidecar
+    image: <Colocated python sidecar image> # Provide colocated python sidecar image
   workers:
   - type: ct5p-hightpu-4t
     topology: 4x4x4
@@ -39,7 +39,7 @@ spec:
           - name: JAX_PLATFORMS
             value: proxy
           - name: JAX_BACKEND_TARGET
-            value: grpc://pathways-remotepython-trial-pathways-head-0-0.pathways-remotepython-trial:29000
+            value: grpc://pathways-colocatedpython-trial-pathways-head-0-0.pathways-colocatedpython-trial:29000
           image: python:3.13
           imagePullPolicy: Always
           command:

--- a/release/install.yaml
+++ b/release/install.yaml
@@ -73,13 +73,13 @@ spec:
                     description: |-
                       DeploymentMode defines whether the user job and the Pathways
                       resources (RM, proxy) must be colocated on TPUs, with the Pathways
-                      workers or not. If user chooses to "colocate", then the Pathways RM
+                      workers or not. If user chooses to "colocate_head_with_workers", then the Pathways RM
                       and proxy run together with the user job as a single pod.
                       Users may opt for "default" placement where scheduler places the
                       RM pod and the proxy pod on the CPU nodepools by default. User
                       workload will be deployed separately, as a pod.
                     enum:
-                    - colocate
+                    - colocate_head_with_workers
                     - default
                     type: string
                     x-kubernetes-validations:
@@ -8108,7 +8108,7 @@ spec:
                       - pathways_server
                       - worker
                       - proxy_server
-                      - remote_python_sidecar
+                      - colocated_python_sidecar
                       type: string
                     customFlags:
                       description: Custom flags to be provided to this component.


### PR DESCRIPTION
Refactor to keep the Colocated Python Feature more consistent with JAX and other documentation.