### PR TITLE
Pass labels to Jobset for integration with kueue.

### DIFF
--- a/internal/controller/pathwaysjob_controller.go
+++ b/internal/controller/pathwaysjob_controller.go
@@ -222,6 +222,7 @@ func (r *PathwaysJobReconciler) createJobSet(ctx context.Context, pw *pathwaysjo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pw.GetName(),
 			Namespace: pw.GetNamespace(),
+			Labels:    pw.GetObjectMeta().GetLabels(),
 		},
 		Spec: jobsetv1alpha2.JobSetSpec{
 			StartupPolicy: &jobsetv1alpha2.StartupPolicy{


### PR DESCRIPTION
Passing kueue related labels to JobSet, so that workloads can be queued. 