### PR TITLE
Inject JAX backend target using main container name. 

### DIFF
--- a/api/v1/pathwaysjob_types.go
+++ b/api/v1/pathwaysjob_types.go
@@ -135,6 +135,7 @@ type WorkerSpec struct {
 
 	// Maximum times the workers in a slice can be restarted.
 	// Used with elasticSlices.
+	// +kubebuilder:default=1
 	MaxSliceRestarts int32 `json:"maxSliceRestarts,omitempty"`
 
 	// The grace period is the duration in seconds after the processes running in the pod are sent
@@ -158,6 +159,9 @@ type ControllerSpec struct {
 	// workload will be deployed separately, as a pod.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="deploymentMode is immutable"
 	DeploymentMode DeploymentMode `json:"deploymentMode"`
+
+	// +kubebuilder:default="main"
+	MainContainerName string `json:"mainContainerName,omitempty"`
 
 	// Enables metrics collection for the PathwaysJob
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="enableMetricsCollection is immutable"

--- a/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
+++ b/config/crd/bases/pathways-job.pathways.domain_pathwaysjobs.yaml
@@ -89,6 +89,9 @@ spec:
                     x-kubernetes-validations:
                     - message: enableMetricsCollection is immutable
                       rule: self == oldSelf
+                  mainContainerName:
+                    default: main
+                    type: string
                   template:
                     description: |-
                       UserPodTemplate accepts a pod composed of user's workload
@@ -8374,6 +8377,7 @@ spec:
                     Pathways workers.
                   properties:
                     maxSliceRestarts:
+                      default: 1
                       description: |-
                         Maximum times the workers in a slice can be restarted.
                         Used with elasticSlices.

--- a/config/samples/colocated_python_example_pathwaysjob.yaml
+++ b/config/samples/colocated_python_example_pathwaysjob.yaml
@@ -15,24 +15,25 @@
 apiVersion: pathways-job.pathways.domain/v1
 kind: PathwaysJob
 metadata:
-  name: pathways-colocatedpython-trial
+  name: pathways-colocated
 spec:
   maxRestarts: 0
   customComponents:
   - componentType: colocated_python_sidecar
     image: <Colocated python sidecar image> # Provide colocated python sidecar image
   workers:
-  - type: ct5p-hightpu-4t
-    topology: 4x4x4
+  - type: ct4p-hightpu-4t
+    topology: 2x2x2
     numSlices: 2
   pathwaysDir: "gs://<test-bucket>/tmp" #This bucket needs to be created in advance.
   controller:
     # #Pod template for training, default mode.
     deploymentMode: default
+    mainContainerName: main
     template: # UserPodTemplate
       spec:
         containers:
-        - name: user
+        - name: main
           env:
           - name: XCLOUD_ENVIRONMENT
             value: GCP

--- a/config/samples/elastic_training_example_pathwaysjob.yaml
+++ b/config/samples/elastic_training_example_pathwaysjob.yaml
@@ -15,12 +15,12 @@
 apiVersion: pathways-job.pathways.domain/v1
 kind: PathwaysJob
 metadata:
-  name: pathways-elastic-trial
+  name: pathways-elastic
 spec:
   maxRestarts: 0
   workers:
-  - type: ct5p-hightpu-4t
-    topology: 4x4x4
+  - type: ct4p-hightpu-4t
+    topology: 2x2x2
     numSlices: 2
     maxSliceRestarts: 4 # For elastic training
   pathwaysDir: "gs://<test-bucket>/tmp" #This bucket needs to be created in advance.
@@ -28,17 +28,11 @@ spec:
     # #Pod template for training, default mode.
     deploymentMode: default
     elasticSlices: 1 # For elastic training
+    mainContainerName: elastic-main
     template: # UserPodTemplate
       spec:
         containers:
-        - name: user
-          env:
-          - name: XCLOUD_ENVIRONMENT
-            value: GCP
-          - name: JAX_PLATFORMS
-            value: proxy
-          - name: JAX_BACKEND_TARGET
-            value: grpc://pathways-elastic-trial-pathways-head-0-0.pathways-elastic-trial:29000
+        - name: elastic-main
           image: python:3.13
           imagePullPolicy: Always
           command:

--- a/config/samples/pathways-job_v1_pathwaysjob.yaml
+++ b/config/samples/pathways-job_v1_pathwaysjob.yaml
@@ -19,25 +19,18 @@ metadata:
 spec:
   maxRestarts: 10
   workers:
-  - type: ct5p-hightpu-4t
-    topology: 4x4x4
+  - type: ct4p-hightpu-4t
+    topology: 2x2x2
     numSlices: 2
-  pathwaysDir: "gs://test-bucket/tmp" #This bucket needs to be created in advance.
+  pathwaysDir: "gs://<test-bucket>/tmp" #This bucket needs to be created in advance.
   controller:
     # #Pod template for training, default mode.
-
+    mainContainerName: main-workload
     deploymentMode: default
     template: # UserPodTemplate
       spec:
         containers:
-        - name: user
-          env:
-          - name: XCLOUD_ENVIRONMENT
-            value: GCP
-          - name: JAX_PLATFORMS
-            value: proxy
-          - name: JAX_BACKEND_TARGET
-            value: grpc://pathways-trial-pathways-head-0-0.pathways-trial:29000
+        - name: main-workload
           image: python:3.13
           imagePullPolicy: Always
           command:

--- a/release/install.yaml
+++ b/release/install.yaml
@@ -97,6 +97,9 @@ spec:
                     x-kubernetes-validations:
                     - message: enableMetricsCollection is immutable
                       rule: self == oldSelf
+                  mainContainerName:
+                    default: main
+                    type: string
                   template:
                     description: |-
                       UserPodTemplate accepts a pod composed of user's workload
@@ -8382,6 +8385,7 @@ spec:
                     Pathways workers.
                   properties:
                     maxSliceRestarts:
+                      default: 1
                       description: |-
                         Maximum times the workers in a slice can be restarted.
                         Used with elasticSlices.


### PR DESCRIPTION
- Injecting JAX env variables for the user's workload container. User shall provide the name of this container in the ControllerSpec via MainContainerName.
- Adding a default for maxSliceRestarts, which will be exercised only if elasticSlices is set but maxSliceRestarts is unset.
- Updating all example configs.
