### PR TITLE
Releasing v0.1.2, with reliable placement of pathways-head.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMAGE_REGISTRY ?= us-docker.pkg.dev/cloud-tpu-v2-images/pathways-job
 IMAGE_NAME ?= pathwaysjob-controller
-IMAGE_TAG ?= v0.1.1
+IMAGE_TAG ?= v0.1.2
 IMG ?= $(IMAGE_REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.30.0

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ The user workload is typically on a Vertex AI notebook, so users can connect to 
 ### Install a released version
 To install the latest released version of PathwaysJob version on your cluster, run the following command:
 ```sh
-VERSION=v0.1.1
+VERSION=v0.1.2
 kubectl apply --server-side -f https://github.com/google/pathways-job/releases/download/$VERSION/install.yaml
 ```
 
 To uninstall the latest released version of PathwaysJob version on your cluster, run the following command:
 ```sh
-VERSION=v0.1.1
+VERSION=v0.1.2
 kubectl delete -f https://github.com/google/pathways-job/releases/download/$VERSION/install.yaml
 ```
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -19,4 +19,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: us-docker.pkg.dev/cloud-tpu-v2-images/pathways-job/pathwaysjob-controller
-  newTag: v0.1.1
+  newTag: v0.1.2

--- a/release/install.yaml
+++ b/release/install.yaml
@@ -8795,7 +8795,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways-job/pathwaysjob-controller:v0.1.1
+        image: us-docker.pkg.dev/cloud-tpu-v2-images/pathways-job/pathwaysjob-controller:v0.1.2
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
This minor release contains and important upgrade - places only one pathways-head pod on one CPU node, in the default mode.