### PR TITLE
Pass capacity node selector to JobSet

### DIFF
--- a/api/v1/pathwaysjob_types.go
+++ b/api/v1/pathwaysjob_types.go
@@ -145,6 +145,9 @@ type WorkerSpec struct {
 
 	// Priority class for the PathwaysJob workers if kueue is configured on the cluster.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// Capacity Node Selector for the PathwaysJob workers.
+	CapacityNodeSelector string `json:"capacityNodeSelector,omitempty"`
 }
 
 // The ControllerSpec struct lists the specifications for the

--- a/config/samples/pathways-job_v1_pathwaysjob.yaml
+++ b/config/samples/pathways-job_v1_pathwaysjob.yaml
@@ -22,6 +22,7 @@ spec:
   - type: ct4p-hightpu-4t
     topology: 2x2x2
     numSlices: 2
+    capacityNodeSelector: "<key>: <value>" # Optional. It should be a valid pair of key and value separated by a colon.
   pathwaysDir: "gs://<test-bucket>/tmp" #This bucket needs to be created in advance.
   controller:
     # #Pod template for training, default mode.


### PR DESCRIPTION
Context: b/440622266

We need to plumb the reservation name so that a Pathways workload can also specify the capacity.