### PR TITLE
Increase rm memory to 32GB

### DIFF
--- a/internal/controller/pathwaysjob_controller.go
+++ b/internal/controller/pathwaysjob_controller.go
@@ -606,7 +606,7 @@ func MakeResourceManagerContainer(pw *pathwaysjob.PathwaysJob, isInitContainer b
 		Args:            args,
 		Env:             env,
 		Ports:           []corev1.ContainerPort{{ContainerPort: PathwaysRMPort}, {ContainerPort: 29002}},
-		Resources:       corev1.ResourceRequirements{Limits: corev1.ResourceList{"cpu": *resource.NewQuantity(8, resource.DecimalSI), "memory": *resource.NewQuantity(16000000000, resource.DecimalSI)}}, // 16GB
+		Resources:       corev1.ResourceRequirements{Limits: corev1.ResourceList{"cpu": *resource.NewQuantity(8, resource.DecimalSI), "memory": *resource.NewQuantity(32000000000, resource.DecimalSI)}}, // 32GB
 	}
 
 	// Init containers can have restartPolicy but regular containers cannot have restartPolicy.


### PR DESCRIPTION
Context: b/448138407

Increase resource manager container memory to 32GB since the current 16 GB limit is frequently reported to OOM by users.