### PR TITLE
Use map NodeSelector instead of string

### DIFF
--- a/api/v1/pathwaysjob_types.go
+++ b/api/v1/pathwaysjob_types.go
@@ -146,8 +146,10 @@ type WorkerSpec struct {
 	// Priority class for the PathwaysJob workers if kueue is configured on the cluster.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 
-	// Capacity Node Selector for the PathwaysJob workers.
-	CapacityNodeSelector string `json:"capacityNodeSelector,omitempty"`
+	// NodeSelector is a selector which must be true for the worker to fit on a node.
+	// Selector which must match a node's labels for the worker to be scheduled on that node.
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // The ControllerSpec struct lists the specifications for the

--- a/config/samples/pathways-job_v1_pathwaysjob.yaml
+++ b/config/samples/pathways-job_v1_pathwaysjob.yaml
@@ -22,7 +22,8 @@ spec:
   - type: ct4p-hightpu-4t
     topology: 2x2x2
     numSlices: 2
-    capacityNodeSelector: "<key>: <value>" # Optional. It should be a valid pair of key and value separated by a colon.
+    nodeSelector:
+      cloud.google.com/reservation-name: reservation-name
   pathwaysDir: "gs://<test-bucket>/tmp" #This bucket needs to be created in advance.
   controller:
     # #Pod template for training, default mode.

--- a/internal/controller/pathwaysjob_controller_test.go
+++ b/internal/controller/pathwaysjob_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -117,106 +118,28 @@ var _ = Describe("PathwaysJob Controller", func() {
 	})
 })
 
-func TestValidateCapacityNodeSelector(t *testing.T) {
-	cases := []struct {
-		desc    string
-		pw      *pathwaysjobv1.PathwaysJob
-		wantErr bool
-	}{
-		{
-			desc: "empty capacity node selector",
-			pw: &pathwaysjobv1.PathwaysJob{
-				Spec: pathwaysjobv1.PathwaysJobSpec{
-					Workers: []pathwaysjobv1.WorkerSpec{
-						{},
-					},
-				},
-			},
-		},
-		{
-			desc: "no colon",
-			pw: &pathwaysjobv1.PathwaysJob{
-				Spec: pathwaysjobv1.PathwaysJobSpec{
-					Workers: []pathwaysjobv1.WorkerSpec{
-						{
-							CapacityNodeSelector: "no colon",
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			desc: "more than 1 colon",
-			pw: &pathwaysjobv1.PathwaysJob{
-				Spec: pathwaysjobv1.PathwaysJobSpec{
-					Workers: []pathwaysjobv1.WorkerSpec{
-						{
-							CapacityNodeSelector: `cloud.google.com/reservation-name:: reservation-name`,
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		{
-			desc: "one colon",
-			pw: &pathwaysjobv1.PathwaysJob{
-				Spec: pathwaysjobv1.PathwaysJobSpec{
-					Workers: []pathwaysjobv1.WorkerSpec{
-						{
-							CapacityNodeSelector: `cloud.google.com/reservation-name: reservation-name`,
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.desc, func(t *testing.T) {
-			got := validateCapacityNodeSelector(tc.pw)
-			if got == nil && tc.wantErr {
-				t.Error("validateCapacityNodeSelector() = nil, want error")
-			}
-			if got != nil && !tc.wantErr {
-				t.Errorf("validateCapacityNodeSelector() = %v, want nil", got)
-			}
-		})
-	}
-}
-
-func TestMakeCapacityNodeSelector(t *testing.T) {
+func TestMakeWorkerJobNodeSelector(t *testing.T) {
 	cases := []struct {
 		desc string
 		pw   *pathwaysjobv1.PathwaysJob
-		want bool
+		want map[string]string
 	}{
 		{
-			desc: "flex start",
+			desc: "no user specified node selector",
 			pw: &pathwaysjobv1.PathwaysJob{
 				Spec: pathwaysjobv1.PathwaysJobSpec{
 					Workers: []pathwaysjobv1.WorkerSpec{
 						{
-							CapacityNodeSelector: `cloud.google.com/gke-queued: "true"`,
+							Type:     "ct4p-hightpu-4t",
+							Topology: "2x2x2",
 						},
 					},
 				},
 			},
-			want: true,
-		},
-		{
-			desc: "spot",
-			pw: &pathwaysjobv1.PathwaysJob{
-				Spec: pathwaysjobv1.PathwaysJobSpec{
-					Workers: []pathwaysjobv1.WorkerSpec{
-						{
-							CapacityNodeSelector: `cloud.google.com/gke-spot: "true"`,
-						},
-					},
-				},
+			want: map[string]string{
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
+				"cloud.google.com/gke-tpu-topology":    "2x2x2",
 			},
-			want: true,
 		},
 		{
 			desc: "reservation",
@@ -224,20 +147,71 @@ func TestMakeCapacityNodeSelector(t *testing.T) {
 				Spec: pathwaysjobv1.PathwaysJobSpec{
 					Workers: []pathwaysjobv1.WorkerSpec{
 						{
-							CapacityNodeSelector: `cloud.google.com/reservation-name: reservation-name`,
+							Type:     "ct4p-hightpu-4t",
+							Topology: "2x2x2",
+							NodeSelector: map[string]string{
+								"cloud.google.com/reservation-name": "reservation-name",
+							},
 						},
 					},
 				},
 			},
-			want: true,
+			want: map[string]string{
+				"cloud.google.com/reservation-name":    "reservation-name",
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
+				"cloud.google.com/gke-tpu-topology":    "2x2x2",
+			},
+		},
+		{
+			desc: "user specify other labels",
+			pw: &pathwaysjobv1.PathwaysJob{
+				Spec: pathwaysjobv1.PathwaysJobSpec{
+					Workers: []pathwaysjobv1.WorkerSpec{
+						{
+							Type:     "ct4p-hightpu-4t",
+							Topology: "2x2x2",
+							NodeSelector: map[string]string{
+								"key": "value",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"key":                                  "value",
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
+				"cloud.google.com/gke-tpu-topology":    "2x2x2",
+			},
+		},
+		{
+			desc: "override accelerator and topology",
+			pw: &pathwaysjobv1.PathwaysJob{
+				Spec: pathwaysjobv1.PathwaysJobSpec{
+					Workers: []pathwaysjobv1.WorkerSpec{
+						{
+							Type:     "ct4p-hightpu-4t",
+							Topology: "2x2x2",
+							NodeSelector: map[string]string{
+								"cloud.google.com/gke-tpu-accelerator": "tpu-v6e-slice",
+								"cloud.google.com/gke-tpu-topology":    "2x2",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{
+				"cloud.google.com/gke-tpu-accelerator": "tpu-v4-podslice",
+				"cloud.google.com/gke-tpu-topology":    "2x2x2",
+			},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, _, got := makeCapacityNodeSelector(tc.pw)
-			if got != tc.want {
-				t.Errorf("makeCapacityNodeSelector() = %v, want %v", got, tc.want)
+			calculateTPUInfo(context.TODO(), tc.pw)
+			got := makeWorkerJobNodeSelector(tc.pw)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("makeWorkerJobNodeSelector() = %v, want %v", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Context: https://github.com/google/pathways-job/pull/35

Colon in a string which is not enclosed by quotes cannot be parsed appropriately. It is better to make this field a map instead.

Note: This change will allow users to specify node selector, which was not allowed previously. Besides, it overrides the accelerator type and topology if they are not aligned with the type and topology specified in other fields. Generally it is not necessary for users to specify the accelerator type and topology in the node selector.